### PR TITLE
Binder fixes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,16 +3,16 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - slycot
-  - lxml
-  - pandas
-  - xlrd
-  - networkx
-  - control
+  - slycot==0.4.0.0
+  - lxml==4.5.0
+  - pandas==0.25.3
+  - xlrd==1.1.0
+  - networkx==2.4
+  - control==0.8.3
+  - orderedset==2.0.3
   - pip
   - pip:
-    - svgpathtools
-    - datetime
-    - cobra
+    - svgpathtools==1.3.3
+    - cobra==0.14.2
     - BondGraphTools==0.3.7
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,1 @@
+pip install numpy==1.19.5 --upgrade


### PR DESCRIPTION
Binder should work with this patch, which forces the image to use a later version of numpy.